### PR TITLE
Replace constant with enums

### DIFF
--- a/src/ClassNameNormalizer.php
+++ b/src/ClassNameNormalizer.php
@@ -15,7 +15,7 @@ final class ClassNameNormalizer extends AbstractNormalizer
 {
     public function __construct(
         string $suffix,
-        string $case = self::PASCAL_CASE,
+        WordCase $case = WordCase::Pascal,
         string $separators = self::DEFAULT_SEPARATORS
     ) {
         parent::__construct($suffix, $case, $separators);

--- a/src/ConstantNameNormalizer.php
+++ b/src/ConstantNameNormalizer.php
@@ -11,7 +11,7 @@ final class ConstantNameNormalizer extends AbstractNormalizer
 {
     public function __construct(
         string $suffix,
-        string $case = self::UPPER_SNAKE,
+        WordCase $case = WordCase::UpperSnake,
         string $separators = self::DEFAULT_SEPARATORS
     ) {
         parent::__construct($suffix, $case, $separators);

--- a/src/NormalizerException.php
+++ b/src/NormalizerException.php
@@ -6,7 +6,6 @@ namespace Kynx\CodeUtils;
 
 use RuntimeException;
 
-use function implode;
 use function sprintf;
 
 /**
@@ -28,18 +27,6 @@ final class NormalizerException extends RuntimeException
         return new self(sprintf(
             "Invalid reserved word suffix '%s': suffix can only contain '[a-zA-Z0-9_\\x80-\\xff]*' characters",
             $suffix
-        ));
-    }
-
-    /**
-     * @param list<string> $validCases
-     */
-    public static function invalidCase(string $case, array $validCases): self
-    {
-        return new self(sprintf(
-            "Invalid case '%s': expected one of '%s'",
-            $case,
-            implode("', '", $validCases)
         ));
     }
 }

--- a/src/PhpLabel.php
+++ b/src/PhpLabel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kynx\CodeUtils;
+
+use function preg_match;
+
+enum PhpLabel: string
+{
+    case Label    = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/u';
+    case Prefix   = '/^[a-zA-Z_\x80-\xff]+$/u';
+    case Suffix   = '/^[a-zA-Z0-9_\x80-\xff]+$/u';
+    case Variable = '/^\$[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/u';
+
+    public function isValid(string $string): bool
+    {
+        return match ($this) {
+            self::Variable => $string !== '$this' && preg_match($this->value, $string) === 1,
+            default        => preg_match($this->value, $string) === 1,
+        };
+    }
+}

--- a/src/PropertyNameNormalizer.php
+++ b/src/PropertyNameNormalizer.php
@@ -9,7 +9,7 @@ namespace Kynx\CodeUtils;
  */
 final class PropertyNameNormalizer extends AbstractNormalizer
 {
-    public function __construct(string $case = self::CAMEL_CASE, string $separators = self::DEFAULT_SEPARATORS)
+    public function __construct(WordCase $case = WordCase::Camel, string $separators = self::DEFAULT_SEPARATORS)
     {
         parent::__construct(null, $case, $separators);
     }

--- a/src/VariableNameNormalizer.php
+++ b/src/VariableNameNormalizer.php
@@ -19,7 +19,7 @@ final class VariableNameNormalizer extends AbstractNormalizer
      */
     public function __construct(
         string $thisReplacement = '$self',
-        string $case = self::CAMEL_CASE,
+        WordCase $case = WordCase::Camel,
         string $separators = self::DEFAULT_SEPARATORS
     ) {
         $this->thisReplacement = str_starts_with($thisReplacement, '$') ? $thisReplacement : '$' . $thisReplacement;

--- a/src/WordCase.php
+++ b/src/WordCase.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kynx\CodeUtils;
+
+use function array_map;
+use function assert;
+use function implode;
+use function lcfirst;
+use function preg_match_all;
+use function strlen;
+use function strtolower;
+use function trim;
+use function ucfirst;
+
+/**
+ * @see \KynxTest\CodeUtils\WordCaseTest
+ */
+enum WordCase: string
+{
+    case Camel      = 'camelCase';
+    case LowerSnake = 'snake_case';
+    case Pascal     = 'PascalCase';
+    case UpperSnake = 'UPPER_SNAKE';
+
+    public function convert(string $string): string
+    {
+        preg_match_all('/[^\s_]+/u', $string, $matches);
+        assert(isset($matches[0]));
+
+        return match ($this) {
+            self::Camel      => $this->toCamel($matches[0]),
+            self::LowerSnake => $this->toLowerSnake($matches[0]),
+            self::Pascal     => $this->toPascal($matches[0]),
+            self::UpperSnake => $this->toUpperSnake($matches[0])
+        };
+    }
+
+    /**
+     * @param list<string> $parts
+     */
+    private function toCamel(array $parts): string
+    {
+        $ucFirst  = array_map(fn (string $part): string => ucfirst(strtolower($part)), $parts);
+        $previous = '';
+        foreach ($ucFirst as $i => $part) {
+            if ($i === 0) {
+                $ucFirst[$i] = lcfirst($part);
+            }
+            if (strlen($previous) === 1 && strlen($part) === 1) {
+                $ucFirst[$i] = strtolower($part);
+            }
+            $previous = $part;
+        }
+
+        return trim(implode('', $ucFirst));
+    }
+
+    /**
+     * @param list<string> $parts
+     */
+    private function toLowerSnake(array $parts): string
+    {
+        return trim(implode('_', array_map('strtolower', $parts)));
+    }
+
+    /**
+     * @param list<string> $parts
+     */
+    private function toPascal(array $parts): string
+    {
+        $ucFirst  = array_map(fn (string $part): string => ucfirst(strtolower($part)), $parts);
+        $previous = '';
+        foreach ($ucFirst as $i => $part) {
+            if (strlen($previous) === 1 && strlen($part) === 1) {
+                $ucFirst[$i] = strtolower($part);
+            }
+            $previous = $part;
+        }
+
+        return trim(implode('', $ucFirst));
+    }
+
+    /**
+     * @param list<string> $parts
+     */
+    private function toUpperSnake(array $parts): string
+    {
+        return trim(implode('_', array_map('strtoupper', $parts)));
+    }
+}

--- a/test/ClassNameNormalizerTest.php
+++ b/test/ClassNameNormalizerTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace KynxTest\CodeUtils;
 
 use Kynx\CodeUtils\ClassNameNormalizer;
-use Kynx\CodeUtils\NormalizerInterface;
+use Kynx\CodeUtils\WordCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @uses \Kynx\CodeUtils\AbstractNormalizer
+ * @uses \Kynx\CodeUtils\PhpLabel
+ * @uses \Kynx\CodeUtils\WordCase
  *
  * @covers \Kynx\CodeUtils\ClassNameNormalizer
  */
@@ -18,7 +20,7 @@ final class ClassNameNormalizerTest extends TestCase
     /**
      * @dataProvider classNameProvider
      */
-    public function testNormalize(string $className, string $case, string $expected): void
+    public function testNormalize(string $className, WordCase $case, string $expected): void
     {
         $normalizer = new ClassNameNormalizer('Reserved', $case);
         $actual     = $normalizer->normalize($className);
@@ -28,21 +30,21 @@ final class ClassNameNormalizerTest extends TestCase
     public function classNameProvider(): array
     {
         return [
-            'unicode_spellout'   => ['€', NormalizerInterface::PASCAL_CASE, 'Euro'],
-            'ascii_spellout'     => ['$', NormalizerInterface::PASCAL_CASE, 'Dollar'],
-            'reserved'           => ['global\fashion', NormalizerInterface::PASCAL_CASE, 'GlobalReserved\Fashion'],
-            'leading_backslash'  => ['\foo\bar', NormalizerInterface::PASCAL_CASE, 'Foo\Bar'],
-            'trailing_backslash' => ['foo\bar\\', NormalizerInterface::PASCAL_CASE, 'Foo\Bar'],
-            'empty_namespace'    => ['foo\\ \\bar', NormalizerInterface::PASCAL_CASE, 'Foo\Bar'],
-            'leading_digits'     => ['cat\9lives', NormalizerInterface::PASCAL_CASE, 'Cat\NineLives'],
-            'camelCase'          => ['home \ sweet home', NormalizerInterface::CAMEL_CASE, 'home\sweetHome'],
+            'unicode_spellout'   => ['€', WordCase::Pascal, 'Euro'],
+            'ascii_spellout'     => ['$', WordCase::Pascal, 'Dollar'],
+            'reserved'           => ['global\fashion', WordCase::Pascal, 'GlobalReserved\Fashion'],
+            'leading_backslash'  => ['\foo\bar', WordCase::Pascal, 'Foo\Bar'],
+            'trailing_backslash' => ['foo\bar\\', WordCase::Pascal, 'Foo\Bar'],
+            'empty_namespace'    => ['foo\\ \\bar', WordCase::Pascal, 'Foo\Bar'],
+            'leading_digits'     => ['cat\9lives', WordCase::Pascal, 'Cat\NineLives'],
+            'camelCase'          => ['home \ sweet home', WordCase::Camel, 'home\sweetHome'],
         ];
     }
 
     public function testNormalizeUsesSeparators(): void
     {
         $expected   = 'FooBarBaz';
-        $normalizer = new ClassNameNormalizer('Reserved', NormalizerInterface::PASCAL_CASE, '|/');
+        $normalizer = new ClassNameNormalizer('Reserved', WordCase::Pascal, '|/');
         $actual     = $normalizer->normalize('Foo|Bar/ Baz');
         self::assertSame($expected, $actual);
     }

--- a/test/ConstantNameNormalizerTest.php
+++ b/test/ConstantNameNormalizerTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace KynxTest\CodeUtils;
 
 use Kynx\CodeUtils\ConstantNameNormalizer;
-use Kynx\CodeUtils\NormalizerInterface;
+use Kynx\CodeUtils\WordCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @uses \Kynx\CodeUtils\AbstractNormalizer
+ * @uses \Kynx\CodeUtils\PhpLabel
+ * @uses \Kynx\CodeUtils\WordCase
  *
  * @covers \Kynx\CodeUtils\ConstantNameNormalizer
  */
@@ -18,7 +20,7 @@ final class ConstantNameNormalizerTest extends TestCase
     /**
      * @dataProvider constantNameProvider
      */
-    public function testNormalize(string $constantName, string $case, string $expected): void
+    public function testNormalize(string $constantName, WordCase $case, string $expected): void
     {
         $normalizer = new ConstantNameNormalizer('RESERVED', $case);
         $actual     = $normalizer->normalize($constantName);
@@ -28,18 +30,18 @@ final class ConstantNameNormalizerTest extends TestCase
     public function constantNameProvider(): array
     {
         return [
-            'unicode_spellout' => ['€ sign', NormalizerInterface::UPPER_SNAKE, 'EURO_SIGN'],
-            'ascii_spellout'   => ['$', NormalizerInterface::UPPER_SNAKE, 'DOLLAR'],
-            'reserved'         => ['exit', NormalizerInterface::UPPER_SNAKE, 'EXIT_RESERVED'],
-            'lead_digits'      => ['12 foo', NormalizerInterface::UPPER_SNAKE, 'ONE_TWO_FOO'],
-            'PascalCase'       => ['foo bar', NormalizerInterface::PASCAL_CASE, 'FooBar'],
+            'unicode_spellout' => ['€ sign', WordCase::UpperSnake, 'EURO_SIGN'],
+            'ascii_spellout'   => ['$', WordCase::UpperSnake, 'DOLLAR'],
+            'reserved'         => ['exit', WordCase::UpperSnake, 'EXIT_RESERVED'],
+            'lead_digits'      => ['12 foo', WordCase::UpperSnake, 'ONE_TWO_FOO'],
+            'PascalCase'       => ['foo bar', WordCase::Pascal, 'FooBar'],
         ];
     }
 
     public function testNormalizeUsesSeparators(): void
     {
         $expected   = 'FOO_BAR_BAZ';
-        $normalizer = new ConstantNameNormalizer('Foo', NormalizerInterface::UPPER_SNAKE, '|/');
+        $normalizer = new ConstantNameNormalizer('Foo', WordCase::UpperSnake, '|/');
         $actual     = $normalizer->normalize('Foo|Bar/ Baz');
         self::assertSame($expected, $actual);
     }

--- a/test/NormalizerExceptionTest.php
+++ b/test/NormalizerExceptionTest.php
@@ -37,13 +37,4 @@ final class NormalizerExceptionTest extends TestCase
         $actual   = NormalizerException::invalidSuffix($suffix);
         self::assertSame($expected, $actual->getMessage());
     }
-
-    public function testInvalidCase(): void
-    {
-        $case     = 'squiggly';
-        $valid    = ['straight', 'bent'];
-        $expected = "Invalid case '$case': expected one of 'straight', 'bent'";
-        $actual   = NormalizerException::invalidCase($case, $valid);
-        self::assertSame($expected, $actual->getMessage());
-    }
 }

--- a/test/PhpLabelTest.php
+++ b/test/PhpLabelTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KynxTest\CodeUtils;
+
+use Kynx\CodeUtils\PhpLabel;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Kynx\CodeUtils\PhpLabel
+ */
+final class PhpLabelTest extends TestCase
+{
+    /**
+     * @dataProvider isValidProvider
+     */
+    public function testIsValid(PhpLabel $label, string $string, bool $expected): void
+    {
+        $actual = $label->isValid($string);
+        self::assertSame($expected, $actual);
+    }
+
+    public function isValidProvider(): array
+    {
+        return [
+            'label_empty'            => [PhpLabel::Label, '', false],
+            'label_number_start'     => [PhpLabel::Label, '1abc', false],
+            'label_hash_start'       => [PhpLabel::Label, '#abc', false],
+            'label_dollar'           => [PhpLabel::Label, 'abc$def', false],
+            'label_not_ascii'        => [PhpLabel::Label, 'abc€def', false],
+            'label_high_ascii_start' => [PhpLabel::Label, '£abc', true],
+            'label_letter'           => [PhpLabel::Label, 'a', true],
+            'label_number'           => [PhpLabel::Label, 'a1', true],
+            'prefix_empty'           => [PhpLabel::Prefix, '', false],
+            'prefix_number'          => [PhpLabel::Prefix, '1', false],
+            'prefix_hash'            => [PhpLabel::Prefix, '#', false],
+            'prefix_not_ascii'       => [PhpLabel::Prefix, '€', false],
+            'prefix_high_ascii'      => [PhpLabel::Prefix, '£', true],
+            'suffix_empty'           => [PhpLabel::Suffix, '', false],
+            'suffix_number'          => [PhpLabel::Suffix, '1', true],
+            'suffix_hash'            => [PhpLabel::Suffix, '#', false],
+            'suffix_not_ascii'       => [PhpLabel::Suffix, '€', false],
+            'suffix_high_ascii'      => [PhpLabel::Suffix, '£', true],
+            'variable_empty'         => [PhpLabel::Variable, '', false],
+            'variable_no_dollar'     => [PhpLabel::Variable, 'abc', false],
+            'variable_this'          => [PhpLabel::Variable, '$this', false],
+            'variable_number_start'  => [PhpLabel::Variable, '$1', false],
+            'variable_hash'          => [PhpLabel::Variable, '$a#', false],
+            'variable_not_ascii'     => [PhpLabel::Variable, '$a€', false],
+            'variable_high_ascii'    => [PhpLabel::Variable, '$£', true],
+        ];
+    }
+}

--- a/test/PropertyNameNormalizerTest.php
+++ b/test/PropertyNameNormalizerTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace KynxTest\CodeUtils;
 
-use Kynx\CodeUtils\NormalizerInterface;
 use Kynx\CodeUtils\PropertyNameNormalizer;
+use Kynx\CodeUtils\WordCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @uses \Kynx\CodeUtils\AbstractNormalizer
+ * @uses \Kynx\CodeUtils\PhpLabel
+ * @uses \Kynx\CodeUtils\WordCase
  *
  * @covers \Kynx\CodeUtils\PropertyNameNormalizer
  */
@@ -18,7 +20,7 @@ final class PropertyNameNormalizerTest extends TestCase
     /**
      * @dataProvider propertyNameProvider
      */
-    public function testNormalizePropertyName(string $propertyName, string $case, string $expected): void
+    public function testNormalizePropertyName(string $propertyName, WordCase $case, string $expected): void
     {
         $normalizer = new PropertyNameNormalizer($case);
         $actual     = $normalizer->normalize($propertyName);
@@ -28,18 +30,18 @@ final class PropertyNameNormalizerTest extends TestCase
     public function propertyNameProvider(): array
     {
         return [
-            'unicode_spellout' => ['€', NormalizerInterface::CAMEL_CASE, 'euro'],
-            'ascii_spellout'   => ['$foo', NormalizerInterface::CAMEL_CASE, 'dollarFoo'],
-            'reserved'         => ['class', NormalizerInterface::CAMEL_CASE, 'class'],
-            'this'             => ['this', NormalizerInterface::CAMEL_CASE, 'this'],
-            'snake_case'       => ['foo bar', NormalizerInterface::SNAKE_CASE, 'foo_bar'],
+            'unicode_spellout' => ['€', WordCase::Camel, 'euro'],
+            'ascii_spellout'   => ['$foo', WordCase::Camel, 'dollarFoo'],
+            'reserved'         => ['class', WordCase::Camel, 'class'],
+            'this'             => ['this', WordCase::Camel, 'this'],
+            'snake_case'       => ['foo bar', WordCase::LowerSnake, 'foo_bar'],
         ];
     }
 
     public function testNormalizeUsesSeparators(): void
     {
         $expected   = 'fooBarBaz';
-        $normalizer = new PropertyNameNormalizer(NormalizerInterface::CAMEL_CASE, '|/');
+        $normalizer = new PropertyNameNormalizer(WordCase::Camel, '|/');
         $actual     = $normalizer->normalize('Foo|Bar/ Baz');
         self::assertSame($expected, $actual);
     }

--- a/test/VariableNameNormalizerTest.php
+++ b/test/VariableNameNormalizerTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace KynxTest\CodeUtils;
 
-use Kynx\CodeUtils\NormalizerInterface;
 use Kynx\CodeUtils\VariableNameNormalizer;
+use Kynx\CodeUtils\WordCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @uses \Kynx\CodeUtils\AbstractNormalizer
+ * @uses \Kynx\CodeUtils\PhpLabel
+ * @uses \Kynx\CodeUtils\WordCase
  *
  * @covers \Kynx\CodeUtils\VariableNameNormalizer
  */
@@ -21,7 +23,7 @@ final class VariableNameNormalizerTest extends TestCase
     public function testNormalizeVariableName(
         string $variableName,
         string $thisReplacement,
-        string $case,
+        WordCase $case,
         string $expected
     ): void {
         $normalizer = new VariableNameNormalizer($thisReplacement, $case);
@@ -32,19 +34,19 @@ final class VariableNameNormalizerTest extends TestCase
     public function variableNameProvider(): array
     {
         return [
-            'unicode_spellout' => ['€', 'me', NormalizerInterface::CAMEL_CASE, '$euro'],
-            'ascii_spellout'   => ['$foo', 'me', NormalizerInterface::CAMEL_CASE, '$dollarFoo'],
-            'reserved'         => ['class', 'me', NormalizerInterface::CAMEL_CASE, '$class'],
-            'this'             => ['this', 'me', NormalizerInterface::CAMEL_CASE, '$me'],
-            '$replacement'     => ['this', '$me', NormalizerInterface::CAMEL_CASE, '$me'],
-            'snake_case'       => ['foo bar', 'me', NormalizerInterface::SNAKE_CASE, '$foo_bar'],
+            'unicode_spellout' => ['€', 'me', WordCase::Camel, '$euro'],
+            'ascii_spellout'   => ['$foo', 'me', WordCase::Camel, '$dollarFoo'],
+            'reserved'         => ['class', 'me', WordCase::Camel, '$class'],
+            'this'             => ['this', 'me', WordCase::Camel, '$me'],
+            '$replacement'     => ['this', '$me', WordCase::Camel, '$me'],
+            'snake_case'       => ['foo bar', 'me', WordCase::LowerSnake, '$foo_bar'],
         ];
     }
 
     public function testNormalizeUsesSeparators(): void
     {
         $expected   = '$fooBarBaz';
-        $normalizer = new VariableNameNormalizer('Reserved', NormalizerInterface::CAMEL_CASE, '|/');
+        $normalizer = new VariableNameNormalizer('Reserved', WordCase::Camel, '|/');
         $actual     = $normalizer->normalize('Foo|Bar/ Baz');
         self::assertSame($expected, $actual);
     }

--- a/test/WordCaseTest.php
+++ b/test/WordCaseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KynxTest\CodeUtils;
+
+use Kynx\CodeUtils\WordCase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Kynx\CodeUtils\WordCase
+ */
+final class WordCaseTest extends TestCase
+{
+    /**
+     * @dataProvider stringProvider
+     */
+    public function testConvert(WordCase $case, string $string, string $expected): void
+    {
+        $actual = $case->convert($string);
+        self::assertSame($expected, $actual);
+    }
+
+    public function stringProvider(): array
+    {
+        return [
+            'empty'       => [WordCase::LowerSnake, '', ''],
+            'just_spaces' => [WordCase::LowerSnake, "  ", ''],
+            'trim'        => [WordCase::LowerSnake, " foo ", 'foo'],
+            'numbers'     => [WordCase::LowerSnake, "foo123 bar", 'foo123_bar'],
+            'underscore'  => [WordCase::LowerSnake, "one two_three", "one_two_three"],
+            'camel'       => [WordCase::Camel, 'FOO bAR', 'fooBar'],
+            'camelAbbr'   => [WordCase::Camel, 'a b foo', 'abFoo'],
+            'lower_snake' => [WordCase::LowerSnake, 'FOO BAR', 'foo_bar'],
+            'Pascal'      => [WordCase::Pascal, 'fOO bAR', 'FooBar'],
+            'PascalAbbr'  => [WordCase::Pascal, 'a b foo', 'AbFoo'],
+            'UPPER_SNAKE' => [WordCase::UpperSnake, 'foo bar', 'FOO_BAR'],
+        ];
+    }
+}


### PR DESCRIPTION
`WordCase`: represents case and provides `toCase()` method for conversion
`PhpLabel`: provides `isValid()` method for validating PHP labels and fragments thereof